### PR TITLE
Calling clustered methods through Vis Clustering Module

### DIFF
--- a/src/components/Network.vue
+++ b/src/components/Network.vue
@@ -145,19 +145,19 @@ export default {
       return this.network.findNode(id);
     },
     getClusteredEdges(baseEdgeId) {
-      return this.network.getClusteredEdges(baseEdgeId);
+      return this.network.clustering.getClusteredEdges(baseEdgeId);
     },
     getBaseEdge(clusteredEdgeId) {
-      return this.network.getBaseEdge(clusteredEdgeId);
+      return this.network.clustering.getBaseEdge(clusteredEdgeId);
     },
     getBaseEdges(clusteredEdgeId) {
-      return this.network.getBaseEdges(clusteredEdgeId);
+      return this.network.clustering.getBaseEdges(clusteredEdgeId);
     },
     updateEdge(startEdgeId, options) {
-      this.network.updateEdge(startEdgeId, options);
+      this.network.clustering.updateEdge(startEdgeId, options);
     },
     updateClusteredNode(clusteredNodeId, options) {
-      this.network.updateClusteredNode(clusteredNodeId, options);
+      this.network.clustering.updateClusteredNode(clusteredNodeId, options);
     },
     isCluster(nodeId) {
       return this.network.isCluster(nodeId);


### PR DESCRIPTION
Hi @alexcode,

Just realized, using the component, that these methods are not on the `Network.prototype` of Vis, therefore they could not be called this way. I also made a [pull request](https://github.com/almende/vis/pull/3846) on Vis to add them, but until they accept it we should go with this workaround.

Regards,