### PR TITLE
Separate Vis from vue2vis

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add the component in the template. You can bind [Visjs event](http://visjs.org/d
 ```html
 <body>
   <div id="app">
-    <timeline ref="timeline" :items="items" :groups="groups" :options="options">
+    <timeline ref="timeline" :items="items" :groups="groups" :options="options" :vis="vis">
     </timeline>
   </div>
 </body>
@@ -55,10 +55,14 @@ Add the component in the template. You can bind [Visjs event](http://visjs.org/d
 
 Add groups, items and options in your observed data or computed.
 ``` javascript
+
+import vis from 'vis';
+
 new Vue({
   el: '#app',
   data() {
     return {
+      vis: vis,
       groups: [{
       	id: 0,
         content: 'Group 1'

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "examples",
+  "name": "vue2vis-examples",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -570,6 +570,8 @@
     },
     "autoprefixer": {
       "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
+      "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
       "dev": true,
       "requires": {
         "browserslist": "2.11.3",
@@ -690,6 +692,8 @@
     },
     "babel-eslint": {
       "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
+      "integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0-beta.42",
@@ -876,6 +880,8 @@
     },
     "babel-helper-vue-jsx-merge-props": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-2.0.3.tgz",
+      "integrity": "sha512-gsLiKK7Qrb7zYJNgiXKpXblxbV5ffSwR0f5whkPAaBAR4fhi6bwRZxX9wBlIc5M/v8CCkXUbXZL4N/nSE97cqg==",
       "dev": true
     },
     "babel-helpers": {
@@ -890,6 +896,8 @@
     },
     "babel-loader": {
       "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
+      "integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
       "dev": true,
       "requires": {
         "find-cache-dir": "1.0.0",
@@ -953,6 +961,8 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -1293,6 +1303,8 @@
     },
     "babel-plugin-transform-runtime": {
       "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
@@ -1310,6 +1322,8 @@
     },
     "babel-plugin-transform-vue-jsx": {
       "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-vue-jsx/-/babel-plugin-transform-vue-jsx-3.7.0.tgz",
+      "integrity": "sha512-W39X07/n3oJMQd8tALBO+440NraGSF//Lo1ydd/9Nme3+QiRGFBb1Q39T9iixh0jZPPbfv3so18tNoIgLatymw==",
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
@@ -1317,6 +1331,8 @@
     },
     "babel-preset-env": {
       "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
@@ -1379,6 +1395,8 @@
     },
     "babel-preset-stage-2": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
+      "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "dev": true,
       "requires": {
         "babel-plugin-syntax-dynamic-import": "6.18.0",
@@ -2406,6 +2424,8 @@
     },
     "copy-webpack-plugin": {
       "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.5.1.tgz",
+      "integrity": "sha512-OlTo6DYg0XfTKOF8eLf79wcHm4Ut10xU2cRBRPMW/NA5F9VMjZGTfRHWDIYC3s+1kObGYrBLshXWU1K0hILkNQ==",
       "dev": true,
       "requires": {
         "cacache": "10.0.4",
@@ -2536,6 +2556,8 @@
     },
     "css-loader": {
       "version": "0.28.11",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
+      "integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
@@ -3026,11 +3048,6 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
-    "emitter-component": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
-      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
-    },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -3218,6 +3235,8 @@
     },
     "eslint": {
       "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -3297,6 +3316,8 @@
     },
     "eslint-config-airbnb-base": {
       "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.2.tgz",
+      "integrity": "sha512-/fhjt/VqzBA2SRsx7ErDtv6Ayf+XLw9LIOqmpBuHFCVwyJo2EtzGWMB9fYRFBoWWQLxmNmCpenNiH0RxyeS41w==",
       "dev": true,
       "requires": {
         "eslint-restricted-globals": "0.1.1"
@@ -3304,6 +3325,8 @@
     },
     "eslint-friendly-formatter": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-friendly-formatter/-/eslint-friendly-formatter-3.0.0.tgz",
+      "integrity": "sha1-J4h0Q1psRuwdlPoLH/SU4w7wQpA=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
@@ -3352,6 +3375,8 @@
     },
     "eslint-import-resolver-webpack": {
       "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.8.4.tgz",
+      "integrity": "sha512-b6JxR57ruiMxq2tIu4T/SrYED5RKJfeBEs8u3+JWF+O2RxDmFpUH84c5uS1T5qiP0K4r0SL7CXhvd41hXdDlAg==",
       "dev": true,
       "requires": {
         "array-find": "1.0.0",
@@ -3394,6 +3419,8 @@
     },
     "eslint-loader": {
       "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.9.0.tgz",
+      "integrity": "sha512-40aN976qSNPyb9ejTqjEthZITpls1SVKtwguahmH1dzGCwQU/vySE+xX33VZmD8csU0ahVNCtFlsPgKqRBiqgg==",
       "dev": true,
       "requires": {
         "loader-fs-cache": "1.0.1",
@@ -3415,6 +3442,8 @@
     },
     "eslint-plugin-import": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
+      "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
       "dev": true,
       "requires": {
         "builtin-modules": "1.1.1",
@@ -3504,6 +3533,8 @@
     },
     "eslint-plugin-vue": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-4.4.0.tgz",
+      "integrity": "sha512-UHeE0aTEv9A/9xe8J6X7rDLMbwV6GuQFKAscMyLEv49Y4wK4KwQiifr2X0MsNsVlmccrDUyjI9KO4DuFTkPP9A==",
       "dev": true,
       "requires": {
         "vue-eslint-parser": "2.0.3"
@@ -3770,6 +3801,8 @@
     },
     "extract-text-webpack-plugin": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz",
+      "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
       "dev": true,
       "requires": {
         "async": "2.6.0",
@@ -3843,6 +3876,8 @@
     },
     "file-loader": {
       "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
+      "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
@@ -4049,6 +4084,8 @@
     },
     "friendly-errors-webpack-plugin": {
       "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.6.1.tgz",
+      "integrity": "sha1-4yeBxHIvVGoGqbXXp8+ihSA3XXA=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
@@ -5169,11 +5206,6 @@
         }
       }
     },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
-    },
     "handle-thing": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
@@ -5354,6 +5386,8 @@
     },
     "html-webpack-plugin": {
       "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz",
+      "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
@@ -6112,11 +6146,6 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
-    "keycharm": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.2.0.tgz",
-      "integrity": "sha1-+m6i5DuQpoAohD0n8gddNajD5vk="
-    },
     "killable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
@@ -6651,11 +6680,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -6820,6 +6844,8 @@
     },
     "node-notifier": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "dev": true,
       "requires": {
         "growly": "1.3.0",
@@ -7058,6 +7084,8 @@
     },
     "optimize-css-assets-webpack-plugin": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-3.2.0.tgz",
+      "integrity": "sha512-Fjn7wyyadPAriuH2DHamDQw5B8GohEWbroBkKoPeP+vSF2PIAPI7WDihi8WieMRb/At4q7Ea7zTKaMDuSoIAAg==",
       "dev": true,
       "requires": {
         "cssnano": "3.10.0",
@@ -7080,6 +7108,8 @@
     },
     "ora": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
+      "integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.2",
@@ -7543,6 +7573,8 @@
     },
     "postcss-import": {
       "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-11.1.0.tgz",
+      "integrity": "sha512-5l327iI75POonjxkXgdRCUS+AlzAdBx4pOvMEhTKTCjb1p8IEeVR9yx3cPbmN7LIWJLbfnIXxAhoB4jpD0c/Cw==",
       "dev": true,
       "requires": {
         "postcss": "6.0.21",
@@ -7604,6 +7636,8 @@
     },
     "postcss-loader": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.3.tgz",
+      "integrity": "sha512-RuBcNE8rjCkIB0IsbmkGFRmQJTeQJfCI88E0VTarPNTvaNSv9OFv1DvTwgtAN/qlzyiELsmmmtX/tEzKp/cdug==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
@@ -7927,6 +7961,8 @@
     },
     "postcss-url": {
       "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-7.3.1.tgz",
+      "integrity": "sha512-Ya5KIjGptgz0OtrVYfi2UbLxVAZ6Emc4Of+Grx4Sf1deWlRpFwLr8FrtkUxfqh+XiZIVkXbjQrddE10ESpNmdA==",
       "dev": true,
       "requires": {
         "mime": "1.6.0",
@@ -8035,14 +8071,6 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
-    },
-    "propagating-hammerjs": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/propagating-hammerjs/-/propagating-hammerjs-1.4.6.tgz",
-      "integrity": "sha1-/tAOmwB2f/1C0U9bUxvEk+tnLjc=",
-      "requires": {
-        "hammerjs": "2.0.8"
-      }
     },
     "proxy-addr": {
       "version": "2.0.3",
@@ -8778,6 +8806,8 @@
     },
     "shelljs": {
       "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
         "glob": "7.1.2",
@@ -9595,6 +9625,8 @@
     },
     "uglifyjs-webpack-plugin": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.4.tgz",
+      "integrity": "sha512-z0IbjpW8b3O/OVn+TTZN4pI29RN1zktFBXLIzzfZ+++cUtZ1ERSlLWgpE/5OERuEUs1ijVQnpYAkSlpoVmQmSQ==",
       "dev": true,
       "requires": {
         "cacache": "10.0.4",
@@ -9796,6 +9828,8 @@
     },
     "url-loader": {
       "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
+      "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
@@ -9908,18 +9942,6 @@
       "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
       "dev": true
     },
-    "vis": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/vis/-/vis-4.21.0.tgz",
-      "integrity": "sha1-3XFji/9/ZJXQC8n0DCU1JhM97Ws=",
-      "requires": {
-        "emitter-component": "1.1.1",
-        "hammerjs": "2.0.8",
-        "keycharm": "0.2.0",
-        "moment": "2.21.0",
-        "propagating-hammerjs": "1.4.6"
-      }
-    },
     "vm-browserify": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
@@ -9930,7 +9952,9 @@
       }
     },
     "vue": {
-      "version": "2.5.16"
+      "version": "2.5.16",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.16.tgz",
+      "integrity": "sha512-/ffmsiVuPC8PsWcFkZngdpas19ABm5mh2wA7iDqcltyCTwlgZjHGeJYOXkBMo422iPwIcviOtrTCUpSfXmToLQ=="
     },
     "vue-eslint-parser": {
       "version": "2.0.3",
@@ -9965,6 +9989,8 @@
     },
     "vue-loader": {
       "version": "13.7.1",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-13.7.1.tgz",
+      "integrity": "sha512-v6PbKMGl/hWHGPxB2uGHsA66vusrXF66J/h1QiFXtU6z5zVSK8jq5xl95M1p3QNXmuEJKNP3nxoXfbgQNs7hJg==",
       "dev": true,
       "requires": {
         "consolidate": "0.14.5",
@@ -10013,6 +10039,8 @@
     },
     "vue-template-compiler": {
       "version": "2.5.16",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.16.tgz",
+      "integrity": "sha512-ZbuhCcF/hTYmldoUOVcu2fcbeSAZnfzwDskGduOrnjBiIWHgELAd+R8nAtX80aZkceWDKGQ6N9/0/EUpt+l22A==",
       "dev": true,
       "requires": {
         "de-indent": "1.0.2",
@@ -10024,14 +10052,6 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz",
       "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==",
       "dev": true
-    },
-    "vue2vis": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/vue2vis/-/vue2vis-0.0.10.tgz",
-      "integrity": "sha1-U+fht2tRCezv37D+9/tySLK++mE=",
-      "requires": {
-        "vis": "4.21.0"
-      }
     },
     "watchpack": {
       "version": "1.5.0",
@@ -10055,6 +10075,8 @@
     },
     "webpack": {
       "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
+      "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
       "dev": true,
       "requires": {
         "acorn": "5.5.3",
@@ -10406,6 +10428,8 @@
     },
     "webpack-bundle-analyzer": {
       "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.11.1.tgz",
+      "integrity": "sha512-VKUVkVMc6TWVXmF1OxsBXoiRjYiDRA4XT0KqtbLMDK+891VX7FCuklYwzldND8J2upUcHHnuXYNTP+4mSFi4Kg==",
       "dev": true,
       "requires": {
         "acorn": "5.5.3",
@@ -10437,6 +10461,8 @@
     },
     "webpack-dev-server": {
       "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
+      "integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
@@ -10481,6 +10507,8 @@
     },
     "webpack-merge": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.2.tgz",
+      "integrity": "sha512-/0QYwW/H1N/CdXYA2PNPVbsxO3u2Fpz34vs72xm03SRfg6bMNGfMJIQEpQjKRvkG2JvT6oRJFpDtSrwbX8Jzvw==",
       "dev": true,
       "requires": {
         "lodash": "4.17.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1450,7 +1450,7 @@
     },
     "compression": {
       "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "dev": true,
       "requires": {
@@ -2042,7 +2042,8 @@
     "emitter-component": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
-      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
+      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY=",
+      "dev": true
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -2562,7 +2563,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
-      "optional": true,
       "requires": {
         "nan": "2.9.2",
         "node-pre-gyp": "0.6.39"
@@ -2571,8 +2571,7 @@
         "abbrev": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ajv": {
           "version": "4.11.8",
@@ -2592,8 +2591,7 @@
         "aproba": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
@@ -2608,32 +2606,27 @@
         "asn1": {
           "version": "0.2.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "assert-plus": {
           "version": "0.2.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aws-sign2": {
           "version": "0.6.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aws4": {
           "version": "1.6.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "balanced-match": {
           "version": "0.4.2",
@@ -2682,14 +2675,12 @@
         "caseless": {
           "version": "0.12.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "co": {
           "version": "4.6.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -2731,7 +2722,6 @@
           "version": "1.14.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
           },
@@ -2739,8 +2729,7 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -2756,8 +2745,7 @@
         "deep-extend": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "delayed-stream": {
           "version": "1.0.0",
@@ -2767,20 +2755,17 @@
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "detect-libc": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "jsbn": "0.1.1"
           }
@@ -2788,8 +2773,7 @@
         "extend": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "extsprintf": {
           "version": "1.0.2",
@@ -2799,8 +2783,7 @@
         "forever-agent": {
           "version": "0.6.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "form-data": {
           "version": "2.1.4",
@@ -2833,7 +2816,6 @@
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "fstream": "1.0.11",
             "inherits": "2.0.3",
@@ -2860,7 +2842,6 @@
           "version": "0.1.7",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
           },
@@ -2868,8 +2849,7 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -2894,8 +2874,7 @@
         "har-schema": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "har-validator": {
           "version": "4.2.1",
@@ -2910,8 +2889,7 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "hawk": {
           "version": "3.1.3",
@@ -2957,8 +2935,7 @@
         "ini": {
           "version": "1.3.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -2971,8 +2948,7 @@
         "is-typedarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "isarray": {
           "version": "1.0.0",
@@ -2982,8 +2958,7 @@
         "isstream": {
           "version": "0.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "jodid25519": {
           "version": "1.0.2",
@@ -2997,8 +2972,7 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -3091,7 +3065,6 @@
           "version": "0.6.39",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "detect-libc": "1.0.2",
             "hawk": "3.1.3",
@@ -3383,7 +3356,6 @@
           "version": "3.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "2.6.8",
             "fstream": "1.0.11",
@@ -3558,7 +3530,8 @@
     "hammerjs": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
+      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=",
+      "dev": true
     },
     "handle-thing": {
       "version": "1.2.5",
@@ -4436,7 +4409,8 @@
     "keycharm": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.2.0.tgz",
-      "integrity": "sha1-+m6i5DuQpoAohD0n8gddNajD5vk="
+      "integrity": "sha1-+m6i5DuQpoAohD0n8gddNajD5vk=",
+      "dev": true
     },
     "killable": {
       "version": "1.0.0",
@@ -4886,7 +4860,8 @@
     "moment": {
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -4914,8 +4889,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
       "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.9",
@@ -6157,6 +6131,7 @@
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/propagating-hammerjs/-/propagating-hammerjs-1.4.6.tgz",
       "integrity": "sha1-/tAOmwB2f/1C0U9bUxvEk+tnLjc=",
+      "dev": true,
       "requires": {
         "hammerjs": "2.0.8"
       }
@@ -7782,6 +7757,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/vis/-/vis-4.21.0.tgz",
       "integrity": "sha1-3XFji/9/ZJXQC8n0DCU1JhM97Ws=",
+      "dev": true,
       "requires": {
         "emitter-component": "1.1.1",
         "hammerjs": "2.0.8",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,9 @@
     "vis",
     "visjs"
   ],
-  "dependencies": {
-    "vis": "^4.21.0"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "vis": "^4.21.0",
     "babel-core": "^6.24.0",
     "babel-loader": "^6.4.0",
     "babel-preset-es2015": "^6.24.0",

--- a/src/components/Graph2d.vue
+++ b/src/components/Graph2d.vue
@@ -3,7 +3,6 @@
 </template>
 
 <script>
-import vis from 'vis';
 
 const events = [
   'click',
@@ -29,6 +28,10 @@ export default {
     },
     options: {
       type: Object
+    },
+    vis: {
+      type: Object,
+      required: true
     }
   },
   data: () => ({
@@ -38,13 +41,13 @@ export default {
     items: {
       deep: true,
       handler(n) {
-        this.graph2d.setItems(new vis.DataSet(n));
+        this.graph2d.setItems(new this.vis.DataSet(n));
       }
     },
     groups: {
       deep: true,
       handler(v) {
-        this.graph2d.setGroups(new vis.DataSet(v));
+        this.graph2d.setGroups(new this.vis.DataSet(v));
       }
     },
     options: {
@@ -112,9 +115,9 @@ export default {
   },
   mounted() {
     const container = this.$refs.visualization;
-    const items = new vis.DataSet(this.items);
-    const groups = new vis.DataSet(this.groups);
-    this.graph2d = new vis.Graph2d(container, items, groups, this.options);
+    const items = new this.vis.DataSet(this.items);
+    const groups = new this.vis.DataSet(this.groups);
+    this.graph2d = new this.vis.Graph2d(container, items, groups, this.options);
     events.forEach(eventName =>
       this.graph2d.on(eventName, props => this.$emit(eventName, props))
     );

--- a/src/components/Network.vue
+++ b/src/components/Network.vue
@@ -3,7 +3,6 @@
 </template>
 
 <script>
-import vis from 'vis';
 
 const events = [
   'click',
@@ -52,6 +51,10 @@ export default {
     options: {
       type: Object,
       default: () => ({})
+    },
+    vis: {
+      type: Object,
+      required: true
     }
   },
   data: () => ({
@@ -67,7 +70,7 @@ export default {
       deep: true,
       handler(n) {
         this.visData.nodes.update(n);
-        var newIds = new vis.DataSet(n).getIds();
+        var newIds = new this.vis.DataSet(n).getIds();
         var oldIds = this.visData.nodes.getIds();
         var diff = getArrayDiff(oldIds, newIds);
         this.visData.nodes.remove(diff);
@@ -77,7 +80,7 @@ export default {
       deep: true,
       handler(e) {
         this.visData.edges.update(e);
-        var newIds = new vis.DataSet(e).getIds();
+        var newIds = new this.vis.DataSet(e).getIds();
         var oldIds = this.visData.edges.getIds();
         var diff = getArrayDiff(oldIds, newIds);
         this.visData.edges.remove(diff);
@@ -92,8 +95,8 @@ export default {
   },
   methods: {
     setData(n, e) {
-      this.visData.nodes = new vis.DataSet(n);
-      this.visData.edges = new vis.DataSet(e);
+      this.visData.nodes = new this.vis.DataSet(n);
+      this.visData.edges = new this.vis.DataSet(e);
       this.network.setData(this.visData);
     },
     destroy() {
@@ -270,9 +273,9 @@ export default {
   },
   mounted() {
     const container = this.$refs.visualization;
-    this.visData.nodes = new vis.DataSet(this.nodes);
-    this.visData.edges = new vis.DataSet(this.edges);
-    this.network = new vis.Network(container, this.visData, this.options);
+    this.visData.nodes = new this.vis.DataSet(this.nodes);
+    this.visData.edges = new this.vis.DataSet(this.edges);
+    this.network = new this.vis.Network(container, this.visData, this.options);
 
     events.forEach(eventName =>
       this.network.on(eventName, props => this.$emit(eventName, props))

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -3,7 +3,6 @@
 </template>
 
 <script>
-import vis from 'vis';
 
 const events = [
   'click',
@@ -46,6 +45,10 @@ export default {
     withTimeTick: {
       type: Boolean,
       default: false
+    },
+    vis: {
+      type: Object,
+      required: true
     }
   },
   data: () => ({
@@ -55,13 +58,13 @@ export default {
     items: {
       deep: true,
       handler(n) {
-        this.timeline.setItems(new vis.DataSet(n));
+        this.timeline.setItems(new this.vis.DataSet(n));
       }
     },
     groups: {
       deep: true,
       handler(v) {
-        this.timeline.setGroups(new vis.DataSet(v));
+        this.timeline.setGroups(new this.vis.DataSet(v));
       }
     },
     options: {
@@ -165,9 +168,9 @@ export default {
   },
   mounted() {
     const container = this.$refs.visualization;
-    const items = new vis.DataSet(this.items);
-    const groups = new vis.DataSet(this.groups);
-    this.timeline = new vis.Timeline(container, items, groups, this.options);
+    const items = new this.vis.DataSet(this.items);
+    const groups = new this.vis.DataSet(this.groups);
+    this.timeline = new this.vis.Timeline(container, items, groups, this.options);
     events.forEach(eventName =>
       this.timeline.on(eventName, props => this.$emit(eventName, props))
     );


### PR DESCRIPTION
Hi @alexcode ,

I don't know what you think about this idea, but this pull request is to separate Vis totally from the Vue component.
This way, vue2vis will no longer be shipped with Vis and the user of the component will have to install Vis by himself and pass it as prop to the vue component.
This has the advantage of letting the user free to choose which version of Vis he wants to work with and also this kinda removes our responsability to bundle and ship vis together with the wrapper.

I did some testing and it seems to be working fine, but please when you have time do some testing yourself as well.

Let me know what you think,

Best regards