### PR TITLE
Fix wrong function binding in Timeline

### DIFF
--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -108,10 +108,10 @@ export default {
       timeline.moveTo(time, options);
     },
     on(event, callback) {
-      timeline.moveTo(event, callback);
+      timeline.on(event, callback);
     },
     off(event, callback) {
-      timeline.moveTo(event, callback);
+      timeline.off(event, callback);
     },
     redraw() {
       timeline.redraw();


### PR DESCRIPTION
Currently `Timeline.on` and `Timeline.off` functions are wrongly bound. This simple patch will fix this.