### PR TITLE
Avoid null error on destroy

### DIFF
--- a/packages/timeline/lib/Timeline.vue
+++ b/packages/timeline/lib/Timeline.vue
@@ -178,7 +178,9 @@ export default {
     this.timeline = null;
   },
   beforeDestroy() {
-    this.timeline.destroy();
+    if (this.timeline !== null) {
+      this.timeline.destroy();
+    }
   }
 };
 </script>


### PR DESCRIPTION
If the component is never mounted, or if there is an error in instantiation, there will be another error because `this.timeline` is null.